### PR TITLE
Remove MixWithOthers for iOS to allow OS bg audio controls

### DIFF
--- a/Superpowered/OpenSource/SuperpoweredIOSAudioIO.mm
+++ b/Superpowered/OpenSource/SuperpoweredIOSAudioIO.mm
@@ -329,7 +329,7 @@ static audioDeviceType NSStringToAudioDeviceType(NSString *str) {
     };
 #ifdef ALLOW_BLUETOOTH
     if (multiRoute) [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryMultiRoute error:NULL];
-    else [[AVAudioSession sharedInstance] setCategory:audioSessionCategory withOptions:AVAudioSessionCategoryOptionAllowBluetoothA2DP | AVAudioSessionCategoryOptionMixWithOthers error:NULL];
+    else [[AVAudioSession sharedInstance] setCategory:audioSessionCategory withOptions:AVAudioSessionCategoryOptionAllowBluetoothA2DP error:NULL];
 #else
     [[AVAudioSession sharedInstance] setCategory:multiRoute ? AVAudioSessionCategoryMultiRoute : audioSessionCategory error:NULL];
 #endif


### PR DESCRIPTION
MixWithOthers prevents iOS from allowing the app to control
audio through the lock screen. Removing this will mean that
iOS will allow the app to be controlled from the lock screen
but also means the app won't allow concurrent audio with
other apps. Audio from other apps will be paused as soon
as the app initializes the Superpowered engine.