### PR TITLE
Revert "Remove MixWithOthers for iOS to allow OS bg audio controls"

### DIFF
--- a/Superpowered/OpenSource/SuperpoweredIOSAudioIO.mm
+++ b/Superpowered/OpenSource/SuperpoweredIOSAudioIO.mm
@@ -329,7 +329,7 @@ static audioDeviceType NSStringToAudioDeviceType(NSString *str) {
     };
 #ifdef ALLOW_BLUETOOTH
     if (multiRoute) [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryMultiRoute error:NULL];
-    else [[AVAudioSession sharedInstance] setCategory:audioSessionCategory withOptions:AVAudioSessionCategoryOptionAllowBluetoothA2DP error:NULL];
+    else [[AVAudioSession sharedInstance] setCategory:audioSessionCategory withOptions:AVAudioSessionCategoryOptionAllowBluetoothA2DP | AVAudioSessionCategoryOptionMixWithOthers error:NULL];
 #else
     [[AVAudioSession sharedInstance] setCategory:multiRoute ? AVAudioSessionCategoryMultiRoute : audioSessionCategory error:NULL];
 #endif


### PR DESCRIPTION
This reverts commit 7a248226590a6f685d1cd6df924c6fca275b8e20.

Original PR: https://github.com/ResonantCavity/Low-Latency-Android-Audio-iOS-Audio-Engine/pull/3

https://github.com/ResonantCavity/voloco_ios/issues/1090

Users have complained that they can't run Voloco in the background and
play music in another app at the same time. The commit this reverts is what
introduced that breaking behavior. Reverting this commit means that the
iOS codebase downstream will need to remove mixWithOthers to enable
lock screen controls when appropriate, which I'll be doing as part of https://github.com/ResonantCavity/voloco_ios/issues/1090.

The main reason for reverting this is to prevent Voloco from stopping other
apps' music as soon as Voloco is launched, because superpowered sets this
category at app launch. The end solution will be to only stop other apps' music 
when a track is played in the app.
