### PR TITLE
Revert "Remove MixWithOthers for iOS to allow OS bg audio controls"

### DIFF
--- a/Superpowered/SuperpoweredIOSAudioIO.mm
+++ b/Superpowered/SuperpoweredIOSAudioIO.mm
@@ -362,7 +362,7 @@ static audioDeviceType NSStringToAudioDeviceType(NSString *str) {
     };
 #ifdef ALLOW_BLUETOOTH
     if (multiRoute) [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryMultiRoute error:NULL];
-    else [[AVAudioSession sharedInstance] setCategory:audioSessionCategory withOptions:AVAudioSessionCategoryOptionAllowBluetoothA2DP error:NULL];
+    else [[AVAudioSession sharedInstance] setCategory:audioSessionCategory withOptions:AVAudioSessionCategoryOptionAllowBluetoothA2DP | AVAudioSessionCategoryOptionMixWithOthers error:NULL];
 #else
     [[AVAudioSession sharedInstance] setCategory:multiRoute ? AVAudioSessionCategoryMultiRoute : audioSessionCategory error:NULL];
 #endif


### PR DESCRIPTION
This reverts commit 5c984bdbea283fd91bd1ba5aac84613a46ddceb0.

See https://github.com/ResonantCavity/Low-Latency-Android-Audio-iOS-Audio-Engine/pull/5 for details.