### PR TITLE
Expose Android AAudio State For Platform Workarounds

### DIFF
--- a/Superpowered/AndroidIO/SuperpoweredAndroidAudioIO.cpp
+++ b/Superpowered/AndroidIO/SuperpoweredAndroidAudioIO.cpp
@@ -550,6 +550,14 @@ void SuperpoweredAndroidAudioIO::stop() {
     if (internals->aaudio) stopAAudio(internals); else stopQueues(internals);
 }
 
+bool SuperpoweredAndroidAudioIO::isAAudioInitialized() {
+    return internals->aaudio;
+}
+
+bool SuperpoweredAndroidAudioIO::isAAudioRestarting() {
+    return internals->aaudio && internals->aaudioRestarting;
+}
+
 void SuperpoweredAndroidAudioIO::resetInputBufferIndices() {
     if (internals->inputFifo.readIndex != internals->inputFifo.writeIndex) {
         internals->inputFifo.readIndex = internals->inputFifo.writeIndex;

--- a/Superpowered/AndroidIO/SuperpoweredAndroidAudioIO.h
+++ b/Superpowered/AndroidIO/SuperpoweredAndroidAudioIO.h
@@ -43,6 +43,12 @@ public:
 
 /// @brief resets the read/write indices of the input FIFO buffer to present accumulating latency
     void resetInputBufferIndices();
+
+/// @brief True, if AAudio was successfully initialized.
+    bool isAAudioInitialized();
+
+/// @brief True, if the AAudio thread is restarting due to a stream disconnect event.
+    bool isAAudioRestarting();
 private:
     SuperpoweredAndroidAudioIOInternals *internals;
     SuperpoweredAndroidAudioIO(const SuperpoweredAndroidAudioIO&);


### PR DESCRIPTION
### Description
----
This PR exposes some Android audio API state / flags used upstream to determine if platform-specific workarounds should be applied. 