### PR TITLE
Forcefully apply buffer size before starting AU graph

### DIFF
--- a/Superpowered/SuperpoweredIOSAudioIO.mm
+++ b/Superpowered/SuperpoweredIOSAudioIO.mm
@@ -510,6 +510,7 @@ static OSStatus coreAudioProcessingCallback(void *inRefCon, AudioUnitRenderActio
 - (bool)start {
     started = true;
     if (audioUnit == NULL) return false;
+    [self applyBuffersize];
     if (AudioOutputUnitStart(audioUnit)) return false;
     audioUnitRunning = true;
     [[AVAudioSession sharedInstance] setActive:YES error:nil];


### PR DESCRIPTION
After lots of testing, this appears to force iOS to be compliant to
what we actually want the buffer size to be. I haven't seen a case
yet where iOS gives us a buffer size that is not what we ask for.

I tried a number of other things but this change appears to be
the most reliable way to get iOS to give us what we want.

Relates to https://github.com/ResonantCavity/voloco_ios/pull/2975