### PR TITLE
Try to fix 1104 buffer sizes on iOS

### DIFF
--- a/Superpowered/OpenSource/SuperpoweredIOSAudioIO.mm
+++ b/Superpowered/OpenSource/SuperpoweredIOSAudioIO.mm
@@ -411,7 +411,7 @@ static void streamFormatChangedCallback(void *inRefCon, AudioUnit inUnit, AudioU
             int minimum = int(self->samplerate * 0.001f), maximum = int(self->samplerate * 0.025f);
             self->minimumNumberOfFrames = nearestPowerOfTwo(minimum / 8) * 8;
             self->maximumNumberOfFrames = nearestPowerOfTwo(maximum / 8) * 8;
-            if (self->maximumNumberOfFrames < 1024) self->maximumNumberOfFrames = 1024;
+            if (self->maximumNumberOfFrames < MAXFRAMES) self->maximumNumberOfFrames = MAXFRAMES;
             if (self->minimumNumberOfFrames < 16) self->minimumNumberOfFrames = 16;
             [self performSelectorOnMainThread:@selector(applyBuffersize) withObject:nil waitUntilDone:NO];
         }


### PR DESCRIPTION
If you have
* iOS 18
* no headset
* Vocal Shortcuts enabled
* Sound Recognition enabled

then iOS returns 1104 frames of audio in the audio processing callback.

This was preventing _any_ audio processing because maximumNumberOfFrames was capped to 1024.

Superpowered already sets up the buffers to be MAXFRAMES, so we should be good in terms of buffer size there.

Vocoder can handle all sorts of varying buffer sizes, and iOS does reinit Vocoder with the iOS buffer size after 20 attempts.

hopefully closes https://github.com/ResonantCavity/voloco_ios/issues/5947