### PR TITLE
Recreate audio unit when hardware rate diverges from client format

### DIFF
--- a/Superpowered/OpenSource/SuperpoweredIOSAudioIO.mm
+++ b/Superpowered/OpenSource/SuperpoweredIOSAudioIO.mm
@@ -53,6 +53,11 @@ static unsigned int nearestPowerOfTwo(unsigned int n) {
     audioDeviceType RemoteIOOutputChannelMap[64];
     uint64_t lastCallbackTime;
     int numberOfChannels, silenceFrames, samplerate, minimumNumberOfFrames, maximumNumberOfFrames;
+    // The sample rate the audio unit's client-side stream format was created with.
+    // If the hardware rate later diverges from this, the unit must be recreated:
+    // CoreAudio would otherwise keep interpreting our output through the stale
+    // client format and silently resample, shifting pitch/speed by the rate ratio.
+    int clientFormatSamplerate;
     bool audioUnitRunning, background, inputEnabled, interleaved;
 }
 
@@ -137,7 +142,7 @@ static unsigned int nearestPowerOfTwo(unsigned int n) {
         audioSystemInfo = [[NSMutableString alloc] initWithCapacity:256];
         silenceFrames = 0;
         background = audioUnitRunning = false;
-        samplerate = minimumNumberOfFrames = maximumNumberOfFrames = 0;
+        samplerate = clientFormatSamplerate = minimumNumberOfFrames = maximumNumberOfFrames = 0;
         externalAudioDeviceName = nil;
         audioUnit = NULL;
         inputBuffer = NULL;
@@ -474,7 +479,18 @@ static void streamFormatChangedCallback(void *inRefCon, AudioUnit inUnit, AudioU
             self->maximumNumberOfFrames = nearestPowerOfTwo(maximum / 8) * 8;
             if (self->maximumNumberOfFrames < MAXFRAMES) self->maximumNumberOfFrames = MAXFRAMES;
             if (self->minimumNumberOfFrames < 16) self->minimumNumberOfFrames = 16;
-            [self performSelectorOnMainThread:@selector(applyBuffersize) withObject:nil waitUntilDone:NO];
+            if (sr != self->clientFormatSamplerate) {
+                // The hardware rate diverged from the rate the audio unit's client
+                // stream format was created with (e.g. the unit was created mid route
+                // change while a headset DAC was still negotiating). CoreAudio would
+                // silently resample through the stale client format, playing our
+                // output pitched/stretched by the rate ratio. Recreate the audio unit
+                // so the client format matches the settled hardware rate.
+                NSLog(@"SuperpoweredIOSAudioIO: hardware samplerate %i diverged from clientFormatSamplerate %i, recreating audio unit", sr, self->clientFormatSamplerate);
+                [self performSelectorOnMainThread:@selector(onMediaServerReset:) withObject:nil waitUntilDone:NO];
+            } else {
+                [self performSelectorOnMainThread:@selector(applyBuffersize) withObject:nil waitUntilDone:NO];
+            }
         }
     }
 }
@@ -584,14 +600,17 @@ static OSStatus coreAudioProcessingCallback(void *inRefCon, AudioUnitRenderActio
     value = inputEnabled ? 1 : 0;
     if (AudioUnitSetProperty(au, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Input, 1, &value, sizeof(value))) { AudioComponentInstanceDispose(au); return NULL; };
 
-    AudioUnitAddPropertyListener(au, kAudioUnitProperty_StreamFormat, streamFormatChangedCallback, (__bridge void *)self);
-
     UInt32 size = 0;
     AudioUnitGetPropertyInfo(au, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &size, NULL);
     AudioStreamBasicDescription format;
     AudioUnitGetProperty(au, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &format, &size);
 
-    samplerate = (int)format.mSampleRate;
+    samplerate = clientFormatSamplerate = (int)format.mSampleRate;
+    NSLog(@"SuperpoweredIOSAudioIO: createRemoteIO clientFormatSamplerate=%i", clientFormatSamplerate);
+
+    // Register the listener after clientFormatSamplerate is set, so a format event
+    // firing during creation can't compare against a stale baseline.
+    AudioUnitAddPropertyListener(au, kAudioUnitProperty_StreamFormat, streamFormatChangedCallback, (__bridge void *)self);
 
     format.mFormatID = kAudioFormatLinearPCM;
     format.mFormatFlags = kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked | kAudioFormatFlagsNativeEndian;

--- a/Superpowered/OpenSource/SuperpoweredIOSAudioIO.mm
+++ b/Superpowered/OpenSource/SuperpoweredIOSAudioIO.mm
@@ -551,8 +551,6 @@ static OSStatus coreAudioProcessingCallback(void *inRefCon, AudioUnitRenderActio
                 self->inputBuffer->mBuffers[n].mNumberChannels = 1;
             }
             self->inputBuffer->mNumberBuffers = self->numberOfChannels;
-            if (!AudioUnitRender(self->audioUnit, ioActionFlags, inTimeStamp, 1, inNumberFrames, self->inputBuffer)) inputs = self->inputBufs;
-
             OSStatus result = AudioUnitRender(self->audioUnit, ioActionFlags, inTimeStamp, 1, inNumberFrames, self->inputBuffer);
 
             if (!result) {

--- a/Superpowered/OpenSource/SuperpoweredIOSAudioIO.mm
+++ b/Superpowered/OpenSource/SuperpoweredIOSAudioIO.mm
@@ -479,7 +479,14 @@ static void streamFormatChangedCallback(void *inRefCon, AudioUnit inUnit, AudioU
             self->maximumNumberOfFrames = nearestPowerOfTwo(maximum / 8) * 8;
             if (self->maximumNumberOfFrames < MAXFRAMES) self->maximumNumberOfFrames = MAXFRAMES;
             if (self->minimumNumberOfFrames < 16) self->minimumNumberOfFrames = 16;
-            if (sr != self->clientFormatSamplerate) {
+            if (self->clientFormatSamplerate == 0) {
+                // The format query at creation time returned 0 (it can before
+                // AudioUnitInitialize). A client format with sample rate 0 inherits
+                // the hardware rate, so there is no divergence: adopt the reported
+                // rate as the baseline.
+                self->clientFormatSamplerate = sr;
+                [self performSelectorOnMainThread:@selector(applyBuffersize) withObject:nil waitUntilDone:NO];
+            } else if (sr != self->clientFormatSamplerate) {
                 // The hardware rate diverged from the rate the audio unit's client
                 // stream format was created with (e.g. the unit was created mid route
                 // change while a headset DAC was still negotiating). CoreAudio would
@@ -604,7 +611,6 @@ static OSStatus coreAudioProcessingCallback(void *inRefCon, AudioUnitRenderActio
     AudioUnitGetProperty(au, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &format, &size);
 
     samplerate = clientFormatSamplerate = (int)format.mSampleRate;
-    NSLog(@"SuperpoweredIOSAudioIO: createRemoteIO clientFormatSamplerate=%i", clientFormatSamplerate);
 
     // Register the listener after clientFormatSamplerate is set, so a format event
     // firing during creation can't compare against a stale baseline.
@@ -630,6 +636,18 @@ static OSStatus coreAudioProcessingCallback(void *inRefCon, AudioUnitRenderActio
     };
 
     if (AudioUnitInitialize(au)) { AudioComponentInstanceDispose(au); return NULL; };
+
+    // The pre-initialize format query can return 0. Now that the unit is
+    // initialized, read back the client-side format to record the rate the unit
+    // will actually interpret our samples with — the baseline for detecting a
+    // stale client format after the hardware rate settles.
+    UInt32 clientSize = 0;
+    AudioStreamBasicDescription clientFormat;
+    AudioUnitGetPropertyInfo(au, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &clientSize, NULL);
+    if (!AudioUnitGetProperty(au, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &clientFormat, &clientSize) && (clientFormat.mSampleRate != 0)) {
+        clientFormatSamplerate = (int)clientFormat.mSampleRate;
+    }
+    NSLog(@"SuperpoweredIOSAudioIO: createRemoteIO clientFormatSamplerate=%i", clientFormatSamplerate);
     return au;
 }
 


### PR DESCRIPTION
## Problem

`createRemoteIO` bakes the sample rate queried at creation time into the audio unit's client-side stream format. `streamFormatChangedCallback` later updates `samplerate` and the buffer size but never the client format. If the unit is recreated mid-renegotiation (e.g. the stop watchdog firing while a replugged headset DAC is still negotiating at 44.1 kHz), the transient rate gets pinned into the client format. When the session settles back to 48 kHz, every layer agrees on 48 kHz but CoreAudio silently resamples output through the stale 44.1 kHz client format — output plays pitched down and time-stretched by 44.1/48 (~1.5 semitones), persistently. The mod-8 frame-count tripwire only catches conversion ratios producing non-multiple-of-8 pulls, so the state can persist indefinitely. Pre-2.8.0 Superpowered recreated the unit on route changes, which masked this; 2.8.0's lighter route handling exposed it.

## Fix

- Track the rate the client format was created with (`clientFormatSamplerate`) and recreate the audio unit whenever the hardware rate diverges from it. Losing the creation race now costs one corrective recreate instead of a permanent pitch shift.
- Handle the pre-initialize zero-rate query: a client format with rate 0 inherits the hardware rate, so a 0 baseline is adopted from the first format event rather than treated as divergence; the real baseline is read back from the client-side format after `AudioUnitInitialize`.
- Register the property listener only after the baseline is set, so a format event firing during creation can't compare against a stale baseline.
- Remove a doubled `AudioUnitRender` in the non-interleaved input path, a leftover from the 2.8.0 upstream merge conflict resolution (dab2b965) that rendered input twice per callback.

## Testing

Verified on iPhone 16 Pro that previously exhibited the pitch-shift on headset plug/unplug — now plays at correct pitch through plug/unplug/replug.

## Ships together with

This widens a pre-existing engine-side race (oversized buffers reaching smaller engine buffers during reinit), so it must ship with the engine bounds guards (already on Vocoder `rezcav`) and the iOS renovate ordering + stop-recording fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)